### PR TITLE
chore(all): remove ndk message, fix eslint warnings

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,6 +5,7 @@
     "sourceType": "script"
   },
   "rules": {
+    "no-empty": ["error", { "allowEmptyCatch": true }],
     "no-implicit-globals": "off"
   },
   "overrides": [

--- a/lib/android.js
+++ b/lib/android.js
@@ -253,11 +253,11 @@ exports.detect = function detect(config, opts, finished) {
 							}
 
 							var archs = {};
-							run(dpkg, '--print-architecture', function (code, stdout, stderr) {
+							run(dpkg, '--print-architecture', function (code, stdout, _stderr) {
 								stdout.split('\n').forEach(function (line) {
 									(line = line.trim()) && (archs[line] = 1);
 								});
-								run(dpkg, '--print-foreign-architectures', function (code, stdout, stderr) {
+								run(dpkg, '--print-foreign-architectures', function (code, stdout, _stderr) {
 									stdout.split('\n').forEach(function (line) {
 										(line = line.trim()) && (archs[line] = 1);
 									});
@@ -278,7 +278,7 @@ exports.detect = function detect(config, opts, finished) {
 							async.each(
 								[ 'libc6:i386', 'libncurses5:i386', 'libstdc++6:i386', 'zlib1g:i386' ],
 								function (pkg, next) {
-									run(dpkgquery, [ '-l', pkg ], function (code, out, err) {
+									run(dpkgquery, [ '-l', pkg ], function (code, out, _err) {
 										result[pkg] = false;
 										if (!code) {
 											var lines = out.split('\n'),
@@ -310,7 +310,7 @@ exports.detect = function detect(config, opts, finished) {
 								return cb();
 							}
 
-							run(rpm, '-qa', function (code, stdout, stderr) {
+							run(rpm, '-qa', function (code, stdout, _stderr) {
 								stdout.split('\n').forEach(function (line) {
 									if (/^glibc-/.test(line)) {
 										if (/\.i[36]86$/.test(line)) {
@@ -362,7 +362,8 @@ exports.detect = function detect(config, opts, finished) {
 				type: 'error',
 				message: __('JDK (Java Development Kit) not found.') + '\n'
 					+ __('If you already have installed the JDK, verify your __JAVA_HOME__ environment variable is correctly set.') + '\n'
-					+ __('The JDK can be downloaded and installed from %s.', '__https://www.oracle.com/technetwork/java/javase/downloads/index.html__')
+					+ __('The JDK can be downloaded and installed from %s', '__https://www.oracle.com/java/technologies/downloads/__') + '\n'
+          + __('or %s.', '__https://jdk.java.net/archive/__')
 			});
 			results.sdk = null;
 			return finalize();
@@ -389,19 +390,6 @@ exports.detect = function detect(config, opts, finished) {
 						+ __('You may be able to fix it by reinstalling your graphics drivers and make sure it installs the 32-bit version.')
 				});
 			}
-		}
-
-		if (!results.ndk) {
-			results.issues.push({
-				id: 'ANDROID_NDK_NOT_FOUND',
-				type: 'warning',
-				message: __('Unable to locate an Android NDK.') + '\n'
-					+ __('Without the NDK, you will not be able to build native Android Titanium modules.') + '\n'
-					+ __('If you have already downloaded and installed the Android NDK, you can tell Titanium where the Android NDK is located by running \'%s\', otherwise you can install it by running \'%s\' or manually downloading from %s.',
-						'__' + commandPrefix + 'titanium config android.ndkPath /path/to/android-ndk__',
-						'__' + commandPrefix + 'titanium setup android__',
-						'__https://developer.android.com/ndk__')
-			});
 		}
 
 		// if we don't have an android sdk, then nothing else to do
@@ -714,8 +702,7 @@ exports.detect = function detect(config, opts, finished) {
 			} else if (message.length > 0) {
 				message += '\n';
 			}
-			message +=
-				__('Current installed Android SDK tools:') + '\n'
+			message += __('Current installed Android SDK tools:') + '\n'
 				+ '  Android SDK Tools:          ' + (results.sdk.tools.version || 'not installed') + '  (Supported: ' + androidPackageJson.vendorDependencies['android tools'] + ')\n'
 				+ '  Android SDK Platform Tools: ' + (results.sdk.platformTools.version || 'not installed') + '  (Supported: ' + androidPackageJson.vendorDependencies['android platform tools'] + ')\n'
 				+ '  Android SDK Build Tools:    ' + (results.sdk.buildTools.version || 'not installed') + '  (Supported: ' + androidPackageJson.vendorDependencies['android build tools'] + ')\n\n'
@@ -1033,7 +1020,7 @@ function loadPlatform(dir, systemImages) {
 	};
 }
 
-function loadAddon(dir, platforms, systemImages) {
+function loadAddon(dir, platforms, _systemImages) {
 	// read in the properties
 	const sourceProps = readProps(path.join(dir, 'source.properties'));
 	const apiLevel = sourceProps ? ~~sourceProps['AndroidVersion.ApiLevel'] : null;

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -150,12 +150,12 @@ Builder.prototype.validate = function validate(logger, config, cli) {
  * Defines common variables prior to running the build. This super function
  * should be called prior to the platform-specific build command's run().
  *
- * @param {Object} logger - The logger instance
- * @param {Object} config - The CLI config
- * @param {Object} cli - The CLI instance
- * @param {Function} finished - A function to call after the function finishes
+ * @param {Object} _logger - The logger instance
+ * @param {Object} _config - The CLI config
+ * @param {Object} _cli - The CLI instance
+ * @param {Function} _finished - A function to call after the function finishes
  */
-Builder.prototype.run = function run(logger, config, cli, finished) {
+Builder.prototype.run = function run(_logger, _config, _cli, _finished) {
 	// note: this function must be sync!
 
 	var buildDirFiles = this.buildDirFiles = {};
@@ -508,7 +508,7 @@ Builder.prototype.generateAppIcons = function generateAppIcons(icons, callback) 
 		return fail();
 	}
 
-	appc.image.resize(defaultIcon, icons, function (error, stdout, stderr) {
+	appc.image.resize(defaultIcon, icons, function (error, _stdout, _stderr) {
 		if (error) {
 			this.logger.error(error);
 			this.logger.log();

--- a/lib/emulators/avd.js
+++ b/lib/emulators/avd.js
@@ -195,7 +195,7 @@ exports.start = function start(config, emu, opts, callback) {
 					cb(tryPort > 5584 ? new Error(__('Unable to find a free port between 5554 and 5584')) : null);
 				});
 
-				socket.on('end', function (err) {
+				socket.on('end', function (_err) {
 					if (socket) {
 						socket.end();
 						socket = null;
@@ -225,11 +225,16 @@ exports.start = function start(config, emu, opts, callback) {
 				var args = [
 					'-avd', emu.id,                                  // use a specific android virtual device
 					'-port', port,                                   // TCP port that will be used for the console
-					'-partition-size', opts.partitionSize || 512     // system/data partition size in MBs
 				];
 
+				if (opts.partitionSize !== undefined) {
+					args.push('-partition-size', opts.partitionSize);  // system/data partition size in MBs
+				}
+
 				var sdcard = opts.sdcard || emu.sdcard;
-				sdcard && args.push('-sdcard', sdcard);              // SD card image (default <system>/sdcard.img
+				if (sdcard !== undefined) {
+					args.push('-sdcard', sdcard);              // SD card image (default <system>/sdcard.img
+				}
 
 				// add any other args
 				opts.logcat               && args.push('-logcat', opts.logcat);                // enable logcat output with given tags

--- a/lib/emulators/genymotion.js
+++ b/lib/emulators/genymotion.js
@@ -101,7 +101,7 @@ exports.detect = function detect(config, opts, finished) {
 			// try to find the VBoxManage file in the config file or system paths
 			appc.subprocess.findExecutable([ config.get('genymotion.executables.vboxmanage'), 'VBoxManage' + exe ], function (err, result) {
 				function getVersion(exe) {
-					appc.subprocess.run(exe, '--version', function (code, out, err) {
+					appc.subprocess.run(exe, '--version', function (code, out, _err) {
 						next(null, {
 							vboxmanage: exe,
 							version: code ? null : out.trim()
@@ -312,7 +312,7 @@ function findGenymotion(dir, config, callback) {
 }
 
 function getVMInfo(config, vboxmanage, callback) {
-	appc.subprocess.run(vboxmanage, [ 'list', 'vms' ], function (code, out, err) {
+	appc.subprocess.run(vboxmanage, [ 'list', 'vms' ], function (code, out, _err) {
 		if (code) {
 			return callback(null, []);
 		}
@@ -337,7 +337,7 @@ function getVMInfo(config, vboxmanage, callback) {
 					'sdk-version': null
 				};
 
-				appc.subprocess.run(vboxmanage, [ 'guestproperty', 'enumerate', emu.guid ], function (code, out, err) {
+				appc.subprocess.run(vboxmanage, [ 'guestproperty', 'enumerate', emu.guid ], function (code, out, _err) {
 					if (!code) {
 						out.split('\n').forEach(function (line) {
 							var m = line.trim().match(/Name: (\S+), value: (\S*), timestamp:/);

--- a/lib/titanium.js
+++ b/lib/titanium.js
@@ -437,7 +437,7 @@ exports.validateCorrectSDK = function (logger, config, cli, commandName) {
 		}
 	}
 
-	function cmdAddSecret(param) {
+	function cmdAddSecret(_param) {
 		for (var i = 0; i < arguments.length; i++) {
 			cmd.push(arguments[i]);
 			cmdSafe.push('*******');
@@ -636,7 +636,7 @@ exports.validateCorrectSDK = function (logger, config, cli, commandName) {
 	setTimeout(function () {
 		spawn(cmdRoot, cmd, {
 			stdio: 'inherit'
-		}).on('exit', function (code, signal) {
+		}).on('exit', function (code, _signal) {
 			code && process.exit(code);
 		});
 	}, delayCmd ? 1000 : 0);

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "node-titanium-sdk",
-      "version": "5.1.5",
+      "version": "5.1.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "^7.8.0",


### PR DESCRIPTION
should merge https://github.com/tidev/node-titanium-sdk/pull/598 first

* remove some eslint warnings
* remove ANDROID_NDK_NOT_FOUND warning (NDK is installed by the CLI since https://github.com/tidev/titanium_mobile/pull/12711)
* add openjdk link to the "install jdk" message and fixed oracle jdk link
* changing avd.js to include partiton-size and image only if it is set (fixes M1 Android black emulator issues)