### PR TITLE
chore: default to ipv4

### DIFF
--- a/lib/adb.js
+++ b/lib/adb.js
@@ -123,7 +123,8 @@ Connection.prototype.exec = function exec(cmd, callback, opts) {
 
 	if (!socket) {
 		socket = this.socket = net.connect({
-			port: this.port
+			port: this.port,
+			family: 4
 		}, function () {
 			DEBUG && console.log('[' + this.connNum + '] CONNECTED');
 


### PR DESCRIPTION
merge https://github.com/tidev/node-titanium-sdk/pull/629 for less lint warnings first

This will set the default to IPv4 for node 17,18,19 support. Beginning with 17 the default setting of `0` will select a IPv6 (https://stackoverflow.com/a/73732144/5193915) and it won't connect to ADB to get the device or emulator and stops.

Setting it to IPv4 will build apps with all node versions up to 19 again!

We could make this a config setting later but since the default was ipv4 before too it shouldn't hurt to keep it at that level.