### PR TITLE
feat: plugin to remove debug/trace methods

### DIFF
--- a/lib/babel-plugins/remove-logs.js
+++ b/lib/babel-plugins/remove-logs.js
@@ -1,0 +1,27 @@
+'use strict';
+
+/**
+ * The actual Babel plugin definition. This plugin removes Ti.API.debug/trace method calls.
+ * @param {object} _ref instance of @babel/types
+ * @returns {object} the instance of the plugin used by Babel during transforms
+ */
+function plugin(_ref) {
+	const types = _ref.types;
+	return {
+		visitor: {
+			CallExpression(path, _state) {
+				const callee = path.get('callee');
+				if (!callee.isMemberExpression()) {
+					return;
+				}
+				if (path.get('callee').matchesPattern('Ti.API.debug')
+					|| path.get('callee').matchesPattern('Titanium.API.debug')
+					|| path.get('callee').matchesPattern('Titanium.API.trace')
+					|| path.get('callee').matchesPattern('Ti.API.trace')) {
+					path.replaceWith(types.nullLiteral());
+				}
+			},
+		}
+	};
+}
+module.exports = plugin;

--- a/lib/jsanalyze.js
+++ b/lib/jsanalyze.js
@@ -147,6 +147,11 @@ exports.analyzeJs = function analyzeJs(contents, opts = {}) {
 		options.presets.push([ env, { targets: opts.targets } ]);
 	}
 
+	if (opts.removeLogs) {
+		// remove trace and debug logs
+		options.plugins.push(require.resolve('./babel-plugins/remove-logs'));
+	}
+
 	// minify
 	if (opts.minify) {
 		Object.assign(options, {


### PR DESCRIPTION
Plugin to remove `Ti.API.debug` and `Ti.API.trace` calls when `removeLogs` is enabled (production builds).

Needs a SDK PR. Test code and more info in that PR