### PR TITLE
fix: arm mac emulator fix

### DIFF
--- a/lib/emulators/avd.js
+++ b/lib/emulators/avd.js
@@ -18,6 +18,7 @@ const appc = require('node-appc'),
 	async = require('async'),
 	android = require('../android'),
 	net = require('net'),
+	os = require('os'),
 	spawn = require('child_process').spawn,
 	EmulatorManager = require('../emulator');
 
@@ -227,13 +228,17 @@ exports.start = function start(config, emu, opts, callback) {
 					'-port', port,                                   // TCP port that will be used for the console
 				];
 
-				if (opts.partitionSize !== undefined) {
-					args.push('-partition-size', opts.partitionSize);  // system/data partition size in MBs
-				}
+				const cpuCore = os.cpus();
+				const isM1 = cpuCore[0].model.includes('Apple');
+				if (!isM1) {
+					if (opts.partitionSize !== undefined) {
+						args.push('-partition-size', opts.partitionSize);  // system/data partition size in MBs
+					}
 
-				var sdcard = opts.sdcard || emu.sdcard;
-				if (sdcard !== undefined) {
-					args.push('-sdcard', sdcard);              // SD card image (default <system>/sdcard.img
+					var sdcard = opts.sdcard || emu.sdcard;
+					if (sdcard !== undefined) {
+						args.push('-sdcard', sdcard);              // SD card image (default <system>/sdcard.img
+					}
 				}
 
 				// add any other args

--- a/lib/emulators/avd.js
+++ b/lib/emulators/avd.js
@@ -18,7 +18,6 @@ const appc = require('node-appc'),
 	async = require('async'),
 	android = require('../android'),
 	net = require('net'),
-	os = require('os'),
 	spawn = require('child_process').spawn,
 	EmulatorManager = require('../emulator');
 
@@ -228,17 +227,12 @@ exports.start = function start(config, emu, opts, callback) {
 					'-port', port,                                   // TCP port that will be used for the console
 				];
 
-				const cpuCore = os.cpus();
-				const isM1 = cpuCore[0].model.includes('Apple');
-				if (!isM1) {
-					if (opts.partitionSize !== undefined) {
-						args.push('-partition-size', opts.partitionSize);  // system/data partition size in MBs
-					}
+				if (opts.partitionSize !== undefined) {
+					args.push('-partition-size', opts.partitionSize);  // system/data partition size in MBs
+				}
 
-					var sdcard = opts.sdcard || emu.sdcard;
-					if (sdcard !== undefined) {
-						args.push('-sdcard', sdcard);              // SD card image (default <system>/sdcard.img
-					}
+				if (opts.sdcard) {
+					args.push('-sdcard', opts.sdcard); // SD card image (default <system>/sdcard.img)
 				}
 
 				// add any other args


### PR DESCRIPTION
I can't test it as I don't have a Arm Mac.

Having those parameters on an Arm Mac won't start the emulator, it will stop with a black screen.
In the old PR at https://github.com/tidev/node-titanium-sdk/pull/629 I've already added a check so it won't include it. But if you have a SDCard assigned in your emulator it will still use the `-sdcard` parameter. 

This PR will ignore both parameters if you are using an Arm Mac. The CPU check part is from:
https://github.com/nodejs/node/issues/41900#issuecomment-1113511254