### PR TITLE
chore: use platform for id

### DIFF
--- a/lib/tiappxml.js
+++ b/lib/tiappxml.js
@@ -17,7 +17,7 @@ const xml = appc.xml;
 const __ = appc.i18n(__dirname).__;
 
 const defaultDOMParserArgs = { errorHandler: function () {} };
-var targetPlatform = '';
+let targetPlatform = '';
 module.exports = tiapp;
 
 function toXml(dom, parent, name, value) {

--- a/lib/tiappxml.js
+++ b/lib/tiappxml.js
@@ -17,7 +17,7 @@ const xml = appc.xml;
 const __ = appc.i18n(__dirname).__;
 
 const defaultDOMParserArgs = { errorHandler: function () {} };
-let targetPlatform = '';
+let targetPlatform;
 module.exports = tiapp;
 
 function toXml(dom, parent, name, value) {
@@ -818,7 +818,7 @@ function toJS(obj, doc) {
 					break;
 
 				case 'id':
-					if (xml.getAttr(node, 'platform') === targetPlatform || obj[node.tagName] === undefined) {
+					if ((targetPlatform && xml.getAttr(node, 'platform') === targetPlatform) || obj[node.tagName] === undefined) {
 						obj[node.tagName] = '' + xml.getValue(node);
 						if (typeof obj[node.tagName] === 'string') {
 							obj[node.tagName] = obj[node.tagName].replace(/\n/g, '');

--- a/lib/tiappxml.js
+++ b/lib/tiappxml.js
@@ -17,7 +17,6 @@ const xml = appc.xml;
 const __ = appc.i18n(__dirname).__;
 
 const defaultDOMParserArgs = { errorHandler: function () {} };
-let targetPlatform;
 module.exports = tiapp;
 
 function toXml(dom, parent, name, value) {
@@ -390,7 +389,7 @@ function toXml(dom, parent, name, value) {
 	node.appendChild(dom.createTextNode('\r\n' + new Array(2).join('\t')));
 }
 
-function toJS(obj, doc) {
+function toJS(obj, doc, targetPlatform) {
 	var node = doc.firstChild;
 	while (node) {
 		if (node.nodeType === xml.ELEMENT_NODE) {
@@ -863,22 +862,21 @@ function toJS(obj, doc) {
 	}
 }
 
-function tiapp(filename, platform = '') {
-	targetPlatform = platform;
+function tiapp(filename, platform) {
 
 	Object.defineProperty(this, 'load', {
 		value: function (file) {
 			if (!fs.existsSync(file)) {
 				throw new Error(__('tiapp.xml file does not exist'));
 			}
-			toJS(this, (new DOMParser(defaultDOMParserArgs).parseFromString(fs.readFileSync(file).toString(), 'text/xml')).documentElement);
+			toJS(this, (new DOMParser(defaultDOMParserArgs).parseFromString(fs.readFileSync(file).toString(), 'text/xml')).documentElement, platform);
 			return this;
 		}
 	});
 
 	Object.defineProperty(this, 'parse', {
 		value: function (str) {
-			toJS(this, (new DOMParser(defaultDOMParserArgs).parseFromString(str, 'text/xml')).documentElement);
+			toJS(this, (new DOMParser(defaultDOMParserArgs).parseFromString(str, 'text/xml')).documentElement, platform);
 			return this;
 		}
 	});

--- a/lib/tiappxml.js
+++ b/lib/tiappxml.js
@@ -17,7 +17,7 @@ const xml = appc.xml;
 const __ = appc.i18n(__dirname).__;
 
 const defaultDOMParserArgs = { errorHandler: function () {} };
-
+var targetPlatform = '';
 module.exports = tiapp;
 
 function toXml(dom, parent, name, value) {
@@ -817,9 +817,17 @@ function toJS(obj, doc) {
 					obj[node.tagName] = node.firstChild && node.firstChild.data.replace(/\n/g, '').trim() || '';
 					break;
 
+				case 'id':
+					if (xml.getAttr(node, 'platform') === targetPlatform || obj[node.tagName] === undefined) {
+						obj[node.tagName] = '' + xml.getValue(node);
+						if (typeof obj[node.tagName] === 'string') {
+							obj[node.tagName] = obj[node.tagName].replace(/\n/g, '');
+						}
+					}
+					break;
+
 				case 'name':
 				case 'guid':
-				case 'id':
 				case 'icon':
 					// need to strip out line returns which shouldn't be there in the first place
 					obj[node.tagName] = '' + xml.getValue(node);
@@ -855,7 +863,9 @@ function toJS(obj, doc) {
 	}
 }
 
-function tiapp(filename) {
+function tiapp(filename, platform = '') {
+	targetPlatform = platform;
+
 	Object.defineProperty(this, 'load', {
 		value: function (file) {
 			if (!fs.existsSync(file)) {


### PR DESCRIPTION
allows you to use `platform="android"` for `<id>`

Tested on Linux/Andorid with:
```xml
	<id platform="android">com.miga.test_android</id>
	<id>com.miga.test</id>
```
and
```xml
	<id>com.miga.test</id>
	<id platform="android">com.miga.test_android</id>
```

both time it will use `com.miga.test_android` at the end.

**TODO**
Need to check it on iOS